### PR TITLE
Use autofs to automount NFS drives

### DIFF
--- a/lib/charms/operator_libs_linux/v1/systemd.py
+++ b/lib/charms/operator_libs_linux/v1/systemd.py
@@ -1,0 +1,288 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Abstractions for stopping, starting and managing system services via systemd.
+
+This library assumes that your charm is running on a platform that uses systemd. E.g.,
+Centos 7 or later, Ubuntu Xenial (16.04) or later.
+
+For the most part, we transparently provide an interface to a commonly used selection of
+systemd commands, with a few shortcuts baked in. For example, service_pause and
+service_resume with run the mask/unmask and enable/disable invocations.
+
+Example usage:
+
+```python
+from charms.operator_libs_linux.v0.systemd import service_running, service_reload
+
+# Start a service
+if not service_running("mysql"):
+    success = service_start("mysql")
+
+# Attempt to reload a service, restarting if necessary
+success = service_reload("nginx", restart_on_failure=True)
+```
+"""
+
+__all__ = [  # Don't export `_systemctl`. (It's not the intended way of using this lib.)
+    "SystemdError",
+    "daemon_reload",
+    "service_disable",
+    "service_enable",
+    "service_failed",
+    "service_pause",
+    "service_reload",
+    "service_restart",
+    "service_resume",
+    "service_running",
+    "service_start",
+    "service_stop",
+]
+
+import logging
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+# The unique Charmhub library identifier, never change it
+LIBID = "045b0d179f6b4514a8bb9b48aee9ebaf"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 1
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 4
+
+
+class SystemdError(Exception):
+    """Custom exception for SystemD related errors."""
+
+
+def _systemctl(*args: str, check: bool = False) -> int:
+    """Control a system service using systemctl.
+
+    Args:
+        *args: Arguments to pass to systemctl.
+        check: Check the output of the systemctl command. Default: False.
+
+    Returns:
+        Returncode of systemctl command execution.
+
+    Raises:
+        SystemdError: Raised if calling systemctl returns a non-zero returncode and check is True.
+    """
+    cmd = ["systemctl", *args]
+    logger.debug(f"Executing command: {cmd}")
+    try:
+        proc = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+            encoding="utf-8",
+            check=check,
+        )
+        logger.debug(
+            f"Command {cmd} exit code: {proc.returncode}. systemctl output:\n{proc.stdout}"
+        )
+        return proc.returncode
+    except subprocess.CalledProcessError as e:
+        raise SystemdError(
+            f"Command {cmd} failed with returncode {e.returncode}. systemctl output:\n{e.stdout}"
+        )
+
+
+def service_running(service_name: str) -> bool:
+    """Report whether a system service is running.
+
+    Args:
+        service_name: The name of the service to check.
+
+    Return:
+        True if service is running/active; False if not.
+    """
+    # If returncode is 0, this means that is service is active.
+    return _systemctl("--quiet", "is-active", service_name) == 0
+
+
+def service_failed(service_name: str) -> bool:
+    """Report whether a system service has failed.
+
+    Args:
+        service_name: The name of the service to check.
+
+    Returns:
+        True if service is marked as failed; False if not.
+    """
+    # If returncode is 0, this means that the service has failed.
+    return _systemctl("--quiet", "is-failed", service_name) == 0
+
+
+def service_start(*args: str) -> bool:
+    """Start a system service.
+
+    Args:
+        *args: Arguments to pass to `systemctl start` (normally the service name).
+
+    Returns:
+        On success, this function returns True for historical reasons.
+
+    Raises:
+        SystemdError: Raised if `systemctl start ...` returns a non-zero returncode.
+    """
+    return _systemctl("start", *args, check=True) == 0
+
+
+def service_stop(*args: str) -> bool:
+    """Stop a system service.
+
+    Args:
+        *args: Arguments to pass to `systemctl stop` (normally the service name).
+
+    Returns:
+        On success, this function returns True for historical reasons.
+
+    Raises:
+        SystemdError: Raised if `systemctl stop ...` returns a non-zero returncode.
+    """
+    return _systemctl("stop", *args, check=True) == 0
+
+
+def service_restart(*args: str) -> bool:
+    """Restart a system service.
+
+    Args:
+        *args: Arguments to pass to `systemctl restart` (normally the service name).
+
+    Returns:
+        On success, this function returns True for historical reasons.
+
+    Raises:
+        SystemdError: Raised if `systemctl restart ...` returns a non-zero returncode.
+    """
+    return _systemctl("restart", *args, check=True) == 0
+
+
+def service_enable(*args: str) -> bool:
+    """Enable a system service.
+
+    Args:
+        *args: Arguments to pass to `systemctl enable` (normally the service name).
+
+    Returns:
+        On success, this function returns True for historical reasons.
+
+    Raises:
+        SystemdError: Raised if `systemctl enable ...` returns a non-zero returncode.
+    """
+    return _systemctl("enable", *args, check=True) == 0
+
+
+def service_disable(*args: str) -> bool:
+    """Disable a system service.
+
+    Args:
+        *args: Arguments to pass to `systemctl disable` (normally the service name).
+
+    Returns:
+        On success, this function returns True for historical reasons.
+
+    Raises:
+        SystemdError: Raised if `systemctl disable ...` returns a non-zero returncode.
+    """
+    return _systemctl("disable", *args, check=True) == 0
+
+
+def service_reload(service_name: str, restart_on_failure: bool = False) -> bool:
+    """Reload a system service, optionally falling back to restart if reload fails.
+
+    Args:
+        service_name: The name of the service to reload.
+        restart_on_failure:
+            Boolean indicating whether to fall back to a restart if the reload fails.
+
+    Returns:
+        On success, this function returns True for historical reasons.
+
+    Raises:
+        SystemdError: Raised if `systemctl reload|restart ...` returns a non-zero returncode.
+    """
+    try:
+        return _systemctl("reload", service_name, check=True) == 0
+    except SystemdError:
+        if restart_on_failure:
+            return service_restart(service_name)
+        else:
+            raise
+
+
+def service_pause(service_name: str) -> bool:
+    """Pause a system service.
+
+    Stops the service and prevents the service from starting again at boot.
+
+    Args:
+        service_name: The name of the service to pause.
+
+    Returns:
+        On success, this function returns True for historical reasons.
+
+    Raises:
+        SystemdError: Raised if service is still running after being paused by systemctl.
+    """
+    _systemctl("disable", "--now", service_name)
+    _systemctl("mask", service_name)
+
+    if service_running(service_name):
+        raise SystemdError(f"Attempted to pause {service_name!r}, but it is still running.")
+
+    return True
+
+
+def service_resume(service_name: str) -> bool:
+    """Resume a system service.
+
+    Re-enable starting the service again at boot. Start the service.
+
+    Args:
+        service_name: The name of the service to resume.
+
+    Returns:
+        On success, this function returns True for historical reasons.
+
+    Raises:
+        SystemdError: Raised if service is not running after being resumed by systemctl.
+    """
+    _systemctl("unmask", service_name)
+    _systemctl("enable", "--now", service_name)
+
+    if not service_running(service_name):
+        raise SystemdError(f"Attempted to resume {service_name!r}, but it is not running.")
+
+    return True
+
+
+def daemon_reload() -> bool:
+    """Reload systemd manager configuration.
+
+    Returns:
+        On success, this function returns True for historical reasons.
+
+    Raises:
+        SystemdError: Raised if `systemctl daemon-reload` returns a non-zero returncode.
+    """
+    return _systemctl("daemon-reload", check=True) == 0

--- a/src/utils/manager.py
+++ b/src/utils/manager.py
@@ -10,26 +10,16 @@ import re
 import shutil
 import subprocess
 from dataclasses import dataclass
-from typing import List, Optional, Tuple, Union
+from typing import Iterator, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 
 import charms.operator_libs_linux.v0.apt as apt
+import charms.operator_libs_linux.v1.systemd as systemd
 
 _logger = logging.getLogger(__name__)
 _nfs_url_check = re.compile(
     r"""
         nfs://[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()!@:%_+.~#?&/=]*)
-    """,
-    re.VERBOSE,
-)
-_mount_parser = re.compile(
-    r"""
-        ^(?P<endpoint>\S+?)\s+
-        (?P<mountpoint>\S+?)\s
-        (?P<fstype>nfs\S*?)\s
-        (?P<options>\S+?)\s
-        (?P<freq>\d+?)\s+
-        (?P<passno>\d+)
     """,
     re.VERBOSE,
 )
@@ -103,24 +93,30 @@ def install() -> None:
     """Install NFS utilities for mounting NFS shares.
 
     Raises:
-        Error: Raised if operation to install NFS common package fails.
+        Error: Raised if this failed to install any of the required packages.
     """
-    _logger.debug("Installing `nfs-common` package from apt archive")
+    _logger.debug("Installing required packages from apt archive.")
     try:
-        apt.update()
-        apt.add_package("nfs-common")
+        apt.add_package(["nfs-common", "autofs"], update_cache=True)
     except (apt.PackageError, apt.PackageNotFoundError) as e:
-        _logger.error(f"Failed to install `nfs-common` package. Reason\n:{e.message}")
+        _logger.error(f"Failed to install required packages. Reason:\n{e.message}")
         raise Error(e.message)
 
 
 def remove() -> None:
-    """Remove NFS utilities for mounting NFS shares."""
-    _logger.debug("Removing `nfs-common` package from system packages")
+    """Remove NFS utilities for mounting NFS shares.
+
+    Raises
+        Error: Raised if a required package was installed but could not be removed.
+    """
+    _logger.debug("Removing required packages from system packages")
     try:
-        apt.remove_package("nfs-common")
-    except apt.PackageNotFoundError:
-        _logger.warning("`nfs-common` package not found on system. Doing nothing")
+        apt.remove_package(["nfs-common", "autofs"])
+    except apt.PackageNotFoundError as e:
+        _logger.warning(f"Skipping package that is not installed. Reason:\n{e}")
+    except apt.PackageError as e:
+        _logger.error(f"Failed to remove required packages. Reason:\n{e}")
+        raise Error("Failed to remove required packages")
 
 
 def fetch(target: str) -> Optional[MountInfo]:
@@ -137,13 +133,13 @@ def fetch(target: str) -> Optional[MountInfo]:
     if _nfs_url_check.match(target):
         target, port = _translate(target)
 
-    # Read /proc/mounts to get current NFS mount information.
-    with pathlib.Path("/proc/mounts").open(mode="rt") as mounts:
-        for mount in mounts.read().splitlines():
-            if nfs_mount := _mount_parser.search(mount):
-                info = nfs_mount.groupdict()
-                if info["mountpoint"] == target or info["endpoint"] == target:
-                    return MountInfo(**info)
+    # We need to trigger an automount for the mounts that are of type `autofs`,
+    # since those could contain a `nfs` or `nfs4` mount.
+    _trigger_autofs()
+
+    for mount in _mounts("nfs"):
+        if mount.mountpoint == target or mount.endpoint == target:
+            return mount
 
     return None
 
@@ -154,13 +150,9 @@ def mounts() -> List[MountInfo]:
     Returns:
         List[MountInfo]: All current NFS mounts on machine.
     """
-    result = []
-    with pathlib.Path("/proc/mounts").open(mode="rt") as mounts:
-        for mount in mounts.read().splitlines():
-            if nfs_mount := _mount_parser.search(mount):
-                result.append(MountInfo(**nfs_mount.groupdict()))
+    _trigger_autofs()
 
-    return result
+    return list(_mounts("nfs"))
 
 
 def mounted(target: str) -> bool:
@@ -169,9 +161,7 @@ def mounted(target: str) -> bool:
     Args:
         target: NFS share endpoint or mountpoint to check.
     """
-    if fetch(target):
-        return True
-    return False
+    return fetch(target) is not None
 
 
 def mount(
@@ -185,55 +175,104 @@ def mount(
         options: Mount options to pass when mounting NFS share.
 
     Raises:
-        Error: Raised if NFS share mount operation fails.
+        Error: Raised if the mount operation fails.
     """
-    # Convert NFS URL to `mount.nfs` format if endpoint is NFS URL.
+    # Convert `endpoint` to the `mount.nfs` format if `endpoint` is an NFS URL.
     if _nfs_url_check.match(endpoint):
         endpoint, port = _translate(endpoint)
     else:
         port = None
 
-    if not (target := pathlib.Path(mountpoint)).exists():
-        _logger.debug(f"Creating mountpoint {target}")
+    # Try to create the mountpoint without checking if it exists to avoid TOCTOU.
+    target = pathlib.Path(mountpoint)
+    try:
         target.mkdir()
+        _logger.debug(f"Created mountpoint {mountpoint}.")
+    except FileExistsError:
+        _logger.warning(f"Mountpoint {mountpoint} already exists.")
 
-    cmd = ["mount", "-t", "nfs"]
+    mount_opts = ""
     if options:
         if port:
             options.append(f"port={port}")
-        cmd.extend(["-o", ",".join(options)])
-    cmd.extend([endpoint, target])
+        mount_opts = ",".join(options)
+
+    _logger.debug(f"Mounting NFS share endpoint {endpoint} at {target} with options {options}")
+    autofs_id = _mountpoint_to_autofs_id(target)
+    master = f"/- /etc/auto.{autofs_id}" + (f" {mount_opts}" if mount_opts else "")
+    pathlib.Path(f"/etc/auto.master.d/{autofs_id}.autofs").write_text(master)
+    pathlib.Path(f"/etc/auto.{autofs_id}").write_text(f"{target} {endpoint}")
+
     try:
-        _logger.debug(f"Mounting NFS share endpoint {endpoint} at {target} with options {options}")
-        subprocess.run(cmd, stderr=subprocess.PIPE, check=True, text=True)
-    except subprocess.CalledProcessError as e:
-        _logger.error(f"{e} Reason:\n{e.stderr}")
-        if "Operation not permitted" in e.stderr and not supported():
+        systemd.service_reload("autofs", restart_on_failure=True)
+    except systemd.SystemdError as e:
+        _logger.error(f"Failed to mount {endpoint} at {target}. Reason:\n{e}")
+        if "Operation not permitted" in str(e) and not supported():
             raise Error("Mounting NFS shares not supported on LXD containers")
         raise Error(f"Failed to mount {endpoint} at {target}")
 
 
-def umount(mountpoint: Union[str, os.PathLike], force: bool = False) -> None:
+def umount(mountpoint: Union[str, os.PathLike]) -> None:
     """Unmount an NFS share.
 
     Args:
         mountpoint: NFS share mountpoint to unmount.
-        force: Pass `--force` option to umount. Default: False.
 
     Raises:
         Error: Raised if NFS share umount operation fails.
     """
-    cmd = ["umount"]
-    if force:
-        cmd.append("--force")
-    cmd.append(mountpoint)
+    _logger.debug(f"Unmounting NFS share at mountpoint {mountpoint}")
+    autofs_id = _mountpoint_to_autofs_id(mountpoint)
+    pathlib.Path(f"/etc/auto.{autofs_id}").unlink(missing_ok=True)
+    pathlib.Path(f"/etc/auto.master.d/{autofs_id}.autofs").unlink(missing_ok=True)
+
     try:
-        _logger.debug(f"Unmounting NFS share at mountpoint {mountpoint}")
-        subprocess.run(cmd, stderr=subprocess.PIPE, check=True, text=True, timeout=120)
-        shutil.rmtree(mountpoint, ignore_errors=True)
-    except subprocess.CalledProcessError as e:
-        _logger.error(f"{e} Reason:\n{e.stderr}")
-        raise Error(f"Failed to unmount {mountpoint}")
-    except subprocess.TimeoutExpired as e:
-        _logger.error(f"{e} Reason:\n{e.stderr}")
-        raise Error(f"Failed to unmount {mountpoint} failed after {e.timeout:.0f}s")
+        systemd.service_reload("autofs", restart_on_failure=True)
+    except systemd.SystemdError as e:
+        _logger.error(f"Failed to unmount {mountpoint}. Reason:\n{e}")
+        raise Error(f"Failed to unmount {mountpoint}.")
+
+    shutil.rmtree(mountpoint, ignore_errors=True)
+
+
+def _trigger_autofs() -> None:
+    """Triggers a mount on all filesystems handled by autofs.
+
+    This function is useful to make autofs-managed mounts appear on the
+    `/proc/mount` file, since they could be unmounted when reading the file.
+    """
+    for fs in _mounts("autofs"):
+        _logger.info(f"triggering automount for `{fs.mountpoint}`")
+        try:
+            os.scandir(fs.mountpoint).close()
+        except OSError as e:
+            # Not critical since it could also be caused by unrelated mounts,
+            # but should be good to log it in case this causes problems.
+            _logger.warning(f"Could not trigger automount for `{fs.mountpoint}`. Reason:\n{e}")
+
+
+def _mountpoint_to_autofs_id(mountpoint: Union[str, os.PathLike]) -> str:
+    """Converts a mountpoint to its corresponding autofs id.
+
+    Args:
+        mountpoint: NFS share mountpoint.
+    """
+    path = pathlib.Path(mountpoint).resolve()
+    return str(path).lstrip("/").replace("/", "-")
+
+
+def _mounts(fstype: str) -> Iterator[MountInfo]:
+    """Gets an iterator of all mounts in the system that have the requested fstype.
+
+    Returns:
+        Iterator[MountInfo]: All the mounts with a valid fstype.
+    """
+    with pathlib.Path("/proc/mounts").open("rt") as mounts:
+        for mount in mounts:
+            # Lines in /proc/mounts follow the standard format
+            # <endpoint> <mountpoint> <fstype> <options> <freq> <passno>
+            m = MountInfo(*mount.split())
+            if not m.fstype.startswith(fstype):
+                continue
+
+            yield m

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -29,13 +29,29 @@ class TestCharm(unittest.TestCase):
         """Test that nfs-client can successfully be installed."""
         self.harness.charm.on.install.emit()
         self.assertEqual(
-            self.harness.model.unit.status, MaintenanceStatus("Installing `nfs-common`")
+            self.harness.model.unit.status, MaintenanceStatus("Installing required packages")
         )
 
     @patch("utils.manager.install", side_effect=nfs.Error("Failed to install `nfs-common`"))
     def test_install_fail(self, _) -> None:
         """Test that nfs-client install fail handler works."""
         self.harness.charm.on.install.emit()
+        self.assertEqual(
+            self.harness.model.unit.status, BlockedStatus("Failed to install `nfs-common`")
+        )
+
+    @patch("utils.manager.install")
+    def test_upgrade_charm(self, _) -> None:
+        """Test that nfs-client installs packages after upgrade."""
+        self.harness.charm.on.upgrade_charm.emit()
+        self.assertEqual(
+            self.harness.model.unit.status, MaintenanceStatus("Installing required packages")
+        )
+
+    @patch("utils.manager.install", side_effect=nfs.Error("Failed to install `nfs-common`"))
+    def test_upgrade_charm_fail(self, _) -> None:
+        """Test that nfs-client install fail handler on upgrade works."""
+        self.harness.charm.on.upgrade_charm.emit()
         self.assertEqual(
             self.harness.model.unit.status, BlockedStatus("Failed to install `nfs-common`")
         )


### PR DESCRIPTION
~Depends on #11~

Fixes #5, and adds an integration test for the bug.

The alternative was to use `systemd` automounts, but there were some issues about system permissions for `systemd` inside LXD containers. `autofs` is more battle-tested, and worked almost perfectly with the correct configuration.

Sidenote: ~~This probably fixes #9, but we'll need to add an integration test for that just to be sure.~~ EDIT: It doesn't, needed more patches to properly allow IPV6 support. See #12.

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [x] All requested changes and/or review comments have been resolved.
