### PR TITLE
Fix project build and cleanup warnings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Can also be used for pull requests.
 
 * `Type: Idea Bank` - Issues that pertain to proposing potential improvement to nfs-client-operator.
 
-* `Type: Enchancement` - Issues marked as an agreed upon enhancement to nfs-client-operator. Can also be used for pull requests.
+* `Type: Enhancement` - Issues marked as an agreed upon enhancement to nfs-client-operator. Can also be used for pull requests.
 
 * `Statues: Help wanted` - Issues where we need help from the greater nfs-client-operator community to solve.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,13 @@ target-version = ["py38"]
 # Linting tools configuration
 [tool.ruff]
 line-length = 99
+extend-exclude = [
+    "__pycache__",
+    "*.egg_info",
+    "lib/charms" # Don't lint charm libraries, lints should be fixed upstream. 
+]
+
+[tool.ruff.lint]
 select = ["E", "W", "F", "C", "N", "D", "I001"]
 extend-ignore = [
     "D203",
@@ -36,8 +43,9 @@ extend-ignore = [
     "D413",
 ]
 ignore = ["E501", "D107"]
-extend-exclude = ["__pycache__", "*.egg_info"]
-per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["D100","D101","D102","D103","D104"]
+
+[tool.ruff.lint.mccabe]
 max-complexity = 10

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -44,10 +44,10 @@ def bootstrap_nfs_server() -> str:
     config = {
         "name": "nfs-server",
         "source": {
-            "alias": "ubuntu/jammy/amd64",
+            "alias": "jammy/amd64",
             "mode": "pull",
             "protocol": "simplestreams",
-            "server": "https://images.linuxcontainers.org",
+            "server": "https://cloud-images.ubuntu.com/releases",
             "type": "image",
         },
         "type": "container",

--- a/tox.ini
+++ b/tox.ini
@@ -69,9 +69,9 @@ commands =
 description = Run nfs-client integration tests
 deps =
     juju==3.1.0.1
-    pylxd==2.3.1
+    pylxd==2.3.2
     pytest==7.2.2
-    pytest-operator==0.26.0
+    pytest-operator==0.31.1
     pytest-order==1.1.0
     pyyaml==6.0
     tenacity==8.2.2


### PR DESCRIPTION
Makes the project build again and fixes some warnings displayed by ruff while trying to lint the project.

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [x] All requested changes and/or review comments have been resolved.