### PR TITLE
fix(ci): CHARMHUB_TOKEN -> CHARMCRAFT_AUTH

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Check libraries
         uses: canonical/charming-actions/check-libraries@2.4.0
         with:
-          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
   unit-test:


### PR DESCRIPTION
## Description

Incorrect secret name `CHARMHUB_TOKEN` is being used within the CI definition. This incorrect name causes the CI to fail when checking the charm library versions because GitHub cannot not find the secret resource. Setting the name to `CHARMCRAFT_AUTH` will fix the issue since the secret name is configured to be `CHARMCRAFT_AUTH`.

## How was the code tested?

Test CI job after merge request is opened by me.

## Related issues and/or tasks

Required to unblock #10, #11, and #12

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [x] All requested changes and/or review comments have been resolved.
