### PR TITLE
Fix ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,7 @@ jobs:
   check-libraries:
     name: Check charm libraries
     runs-on: ubuntu-latest
+    permissions: write-all
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,6 @@ jobs:
       - name: Check libraries
         uses: canonical/charming-actions/check-libraries@2.4.0
         with:
-          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
   unit-test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Check libraries
         uses: canonical/charming-actions/check-libraries@2.4.0
         with:
-          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
   unit-test:


### PR DESCRIPTION
## Description

Drops credentials from `check-libraries` step in the CI since forks do not have access to the `CHARMCRAFT_AUTH` secret I have configured. As of https://github.com/canonical/charmcraft/pull/1037, we can now check the libraries anonymously without having to be logged into Charmhub.

## How was the code tested?

GitHub CI runner

## Related issues and/or tasks

#13 failed to apply the fix 

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [x] All requested changes and/or review comments have been resolved.
