### PR TITLE
Drop `check-libraries` job from CI pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,20 +29,6 @@ jobs:
       - name: Run linters
         run: tox -e lint
 
-  check-libraries:
-    name: Check charm libraries
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@2.4.0
-        with:
-          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
   unit-test:
     name: Unit tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Dropping check-libraries job because (a) we do not use it anywhere else in the HPC charms, and (b) the action does not work if a community contributor opens a merge request from a fork rather than a branch on the same repository.

## How was the code tested?

GitHub CI runner

## Related issues and/or tasks

Not fixed by #13, and blocks #10, #11, and #12 

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [x] All requested changes and/or review comments have been resolved.
