### PR TITLE
fix(ci): Remove job dep for integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,6 @@ jobs:
     needs:
       - inclusive-naming-check
       - lint
-      - check-libraries
       - unit-test
     timeout-minutes: 120
     steps:


### PR DESCRIPTION
Accidentally forgot to remove this before merging the CI fixes.
